### PR TITLE
Add scaffolds, sample data, first round of logic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 ruby "3.3.1"
 
 gem "positioning"
+gem "faker"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.1.3", ">= 7.1.3.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,8 @@ GEM
       railties (>= 6.1)
     drb (2.2.1)
     erubi (1.12.0)
+    faker (3.3.1)
+      i18n (>= 1.8.11, < 2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.5)
@@ -382,6 +384,7 @@ DEPENDENCIES
   bullet
   debug
   dotenv-rails
+  faker
   importmap-rails
   jbuilder
   pg (~> 1.1)

--- a/app/models/run_unit.rb
+++ b/app/models/run_unit.rb
@@ -21,7 +21,32 @@
 #  fk_rails_...  (run_id => runs.id)
 #
 class RunUnit < ApplicationRecord
-  belongs_to :run
+  validates :indentation_level, numericality: { greater_than_or_equal_to: 0 }
+
+  validate :not_too_deep
 
   positioned on: :run
+
+  belongs_to :run
+
+  def not_too_deep
+    if indentation_level > predecessor.indentation_level + 1
+      errors.add(:indentation_level, "must not be more than one level deeper than its predecessor")
+    end
+  end
+
+  alias_method :predecessor, :prior_position
+  alias_method :successor, :subsequent_position
+
+  def descendants
+    result = []
+    next_unit = successor
+
+    while next_unit && next_unit.indentation_level > indentation_level
+      result << next_unit
+      next_unit = next_unit.successor
+    end
+
+    result
+  end
 end

--- a/app/models/run_unit.rb
+++ b/app/models/run_unit.rb
@@ -49,4 +49,34 @@ class RunUnit < ApplicationRecord
 
     result
   end
+
+  # Pseudocode for methods we may not need, mostly just to define terminology:
+
+  # def siblings
+  #   run.run_units.where(indentation_level:).order(:position)
+  # end
+
+  # def successors
+  #   run.run_units.where(position: position...).order(:position)
+  # end
+
+  # def predecessors
+  #   run.run_units.where(position: ...position).order(:position)
+  # end
+
+  # def parent
+  #   run.run_units.where(indentation_level: indentation_level - 1).order(position: :desc).first
+  # end
+
+  # def ancestors
+  #   next_ancestor = parent
+  #   result = []
+
+  #   while next_ancestor
+  #     result << next_ancestor
+  #     next_ancestor = next_ancestor.parent
+  #   end
+
+  #   result
+  # end
 end

--- a/app/views/runs/show.html.erb
+++ b/app/views/runs/show.html.erb
@@ -14,8 +14,13 @@
   <% @run.run_units.order(:position).each do |run_unit| %>
     <div style="margin-left: <%= run_unit.indentation_level * 5 %>px">
       <div>
-        <%= "•" * run_unit.indentation_level %>
-        <%= run_unit.indentation_level %>: <%= run_unit.title %>
+        <div>
+          <%= "•" * run_unit.indentation_level %> <%= run_unit.id %>: <%= run_unit.title %>
+
+          | 
+
+          Descendants: <%= run_unit.descendants.map(&:id) %>
+        </div>
       </div>
     </div>
   <% end %>

--- a/app/views/runs/show.html.erb
+++ b/app/views/runs/show.html.erb
@@ -8,3 +8,15 @@
 
   <%= button_to "Destroy this run", @run, method: :delete %>
 </div>
+
+<h2>Run Units</h2>
+<div>
+  <% @run.run_units.order(:position).each do |run_unit| %>
+    <div style="margin-left: <%= run_unit.indentation_level * 5 %>px">
+      <div>
+        <%= "•" * run_unit.indentation_level %>
+        <%= run_unit.indentation_level %>: <%= run_unit.title %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,8 @@
 Rails.application.routes.draw do
+  root "runs#index"
+
   resources :run_units
   resources :runs
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", :as => :rails_health_check
-
-  # Defines the root path route ("/")
-  # root "posts#index"
 end

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,0 +1,28 @@
+namespace :dev do
+  desc "Hydrate db with sample data"
+  task prime: :environment do
+    Run.destroy_all
+
+    5.times do
+      run = Run.create(
+        title: Faker::Educator.course_name,
+        description: Faker::Lorem.paragraph(sentence_count: 3)
+      )
+
+      1.upto(100) do |i|
+        run_unit = run.run_units.create(
+          title: "#{i.ordinalize} unit",
+          description: Faker::Lorem.paragraph(sentence_count: 3)
+        )
+
+        next if i == 1
+
+        predecessor_il = run_unit.prior_position.indentation_level
+
+        indentation_level = rand(0..(predecessor_il + 1))
+
+        run_unit.update(indentation_level:)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Before this PR:

- generated `Run` and `RunUnit` scaffolds
- added [positioning gem](https://github.com/brendon/positioning) and positioned `RunUnit` on `:run`

In this PR:

- Define `predecessor` — the unit just before me, by `position`.
- Define `successor` — the unit just after me, by `position`.
- Validate that my `indentation_level` is between 0 and 1 more than my predecessor's.
- Define `descendants` — the units up until my next sibling ("siblings": units with my same indentation level).
- Add sample data.
- Show data in `runs#show`.
- Add pseudocode for methods we may not need (`parent`, `ancestors`, etc), mostly to suggest terminology.